### PR TITLE
Issue#2

### DIFF
--- a/proj4/Naruto.pde
+++ b/proj4/Naruto.pde
@@ -66,7 +66,7 @@ class Naruto{
       varWidth = -10;
       narutoWidth = counter * spriteWidth + varWidth;
       
-      //rasengan_current++;
+      rasengan_current++;
     } 
     sX = narutoWidth - spriteWidth;
     copy(spriteSection, sX, sY, narutoWidth , narutoHeight, (int)position.x, (int)position.y, spriteWidth, narutoHeight);

--- a/proj4/Naruto.pde
+++ b/proj4/Naruto.pde
@@ -42,6 +42,14 @@ class Naruto{
     copy(spriteSection, sX, sY, narutoWidth , narutoHeight, (int)position.x, (int)position.y, spriteWidth, narutoHeight);
   }
   
+  void drawNarutoStanceFlipped(){
+    sX = 0;
+    sY = 0;
+    varWidth = 12;
+    narutoWidth = spriteWidth + varWidth;
+    copy(spriteSection, sX, sY, narutoWidth , narutoHeight, (int)position.x, (int)position.y, spriteWidth, narutoHeight);
+  }
+  
   void drawNarutoRasengan(int counter){
     
     int multiplier = 12;

--- a/proj4/SpriteFrame.pde
+++ b/proj4/SpriteFrame.pde
@@ -1,5 +1,6 @@
 class SpriteFrame{
   PImage sprite;
+  PImage spriteFlipped;
   
   
   SpriteFrame(String imgFile){
@@ -7,15 +8,34 @@ class SpriteFrame{
     sprite.format = ARGB;
     sprite.loadPixels();
     sprite = transparentizeBackground(sprite, sprite.pixels[0]);
+    
+    // 
+    //https://processing.org/discourse/beta/num_1203607253.html
+    // http://stackoverflow.com/questions/29334348/processing-mirror-image-over-x-axis
+    spriteFlipped = createImage(sprite.width,sprite.height,ARGB);//create a new image with the same dimensions
+    for(int y = 0; y < sprite.height; y++){
+      for(int x = 0; x < sprite.width; x++){
+        spriteFlipped.set(sprite.width-x-1,y,sprite.get(x,y));
+      }
+    }
+    
+    spriteFlipped.loadPixels();
+    spriteFlipped = transparentizeBackground(spriteFlipped, spriteFlipped.pixels[0]);
+    
   }
   
   PImage get(int x, int y, int w, int h){
     return sprite.get(x, y, w, h);
   }
+  PImage getFlipped(int x, int y, int w, int h){
+    return spriteFlipped.get(x, y, w, h);
+  }
+  
+  PImage getFlippedFull() {
+    return spriteFlipped;
+  }
   
   
-  
-  
-  
+ 
   
 }

--- a/proj4/proj4.pde
+++ b/proj4/proj4.pde
@@ -28,20 +28,24 @@ final int MAX_RASENGAN = 120;
 final int FRAME_RATE = 60;
 
 Naruto naruto;
+Naruto narutoEnemy;
+
 SpriteFrame sprite01;
+SpriteFrame sprite01Flipped;
 
 PImage[] rasengans = new PImage[MAX_RASENGAN];
 int rasengan_current = 0;
 
 int xRasengan = 0;
 int yRasengan = 0;
-int xNaruto = 0, yNaruto = 0;
+//int xNaruto = 0, yNaruto = 0; // I believe this should have gotten commented out with refator of global into Narto Class
 
 
 PImage background;
 
 PImage spriteRasengan;
 PImage spriteNarutoClone;
+PImage spriteNarutoCloneEnemy;
 
 int rWidth = 0;
 int rHeight = 0;
@@ -66,13 +70,22 @@ void setup() {
   frameRate(FRAME_RATE);
   background = loadImage("sand_background.png");
   sprite01 = new SpriteFrame("Naruto_04.png");
+ 
+  
+  //background = sprite01.getFlippedFull();
+  
   spriteNarutoClone = sprite01.get(0, 4540, 260, 60);// Naruto Clone
-
+  spriteNarutoCloneEnemy =sprite01.getFlipped(sprite01.getFlippedFull().width - 260,4540, 260, 60);// Naruto Clone Enemy
+  
+  
   naruto = new Naruto(spriteNarutoClone);
+  // Naruto(float x, float y, float vX, float vY, PImage sprite)
+  // this.position = new PVector(230, (background.height - (segmentHeight * 3 - 7)) );
+  narutoEnemy = new Naruto(.8 * background.width, (background.height - (segmentHeight * 3 - 7)), 0, 0,  spriteNarutoCloneEnemy);
   
   surface.setResizable(true);
   surface.setSize(background.width, background.height);
-  
+  rect(0,0, 260, 60);
   for(int i = 0; i < MAX_RASENGAN; i++){
     rasengans[i] = sprite01.get(0, 4150, 500, 70);// OOdama Rasengan
     dx[i] = (int)naruto.position.x + 15;
@@ -87,6 +100,7 @@ void setup() {
 
 void draw() {
   image(background, 0, 0);
+  rect(sprite01.getFlippedFull().width - 260,4540, 260, 60);
   background.resize(width, height);
   
   //drawNaruto(counter);
@@ -124,18 +138,23 @@ void draw() {
       case(RIGHT):
         PVector moveRight = new PVector(5, 0);
         naruto.moveHorizontal(moveRight);
+        narutoEnemy.drawNarutoStanceFlipped();
         break;
       
       case(LEFT):
         PVector moveLeft = new PVector(-5, 0);
         naruto.moveHorizontal(moveLeft);
+
         break;
       
     } // End Switch
+    narutoEnemy.drawNarutoStanceFlipped();
   } // End If
   else{
     naruto.velocity = new PVector(0, 0);
     naruto.drawNarutoStance(); 
+    
+    narutoEnemy.drawNarutoStanceFlipped();
   }
   counter++;
 }


### PR DESCRIPTION
uncommented that one line. It doesnt' really do much at this point except enable the rasengan_current variable to increment 
which then allows a for loop in the draw() method to actually start to exercise.
but observed that once a rasengan object is created, nothing currently removes it from the rasengans
which appears to be tracked currently by the global dx[i], dy[i] variables. 

Looking at the code, I think we need to look at making each rasengan be self contained.
e.g. Once it is a live, it has a certain velocity/trajectory.
the main draw loop should be simple, draw all visible objects. Timer threads in the background shouldn't be modifying objects when the draw command is accessign them. However, perhaps either at the end of the draw command, maybe it allows any pending object threads to modify ojbect states before it gets called again?
